### PR TITLE
chore: TypeScriptビルド成果物を.gitignoreに追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,8 @@ yarn-error.log*
 
 # Mise
 .mise.lock
+
+# TypeScript build outputs (transpiled from .ts files)
+/docusaurus.config.js
+/sidebars.js
+/src/**/*.js


### PR DESCRIPTION
- docusaurus.config.js, sidebars.js, src/**/*.js を無視リストに追加
- これらはTypeScriptからトランスパイルされたビルド成果物のため、リポジトリに含めるべきではない