### PR TITLE
feat: ナビバーとフッターにブログアーカイブへのリンクを追加

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -105,6 +105,7 @@ const config: Config = {
           label: 'Profile',
         },
         {to: '/blog', label: 'Blog', position: 'left'},
+        {to: '/blog/archive', label: 'Archive', position: 'left'},
       ],
     },
     footer: {
@@ -120,6 +121,10 @@ const config: Config = {
             {
               label: 'Blog',
               to: '/blog',
+            },
+            {
+              label: 'Blog Archive',
+              to: '/blog/archive',
             },
           ],
         },


### PR DESCRIPTION
## Summary
- ナビバーに「Archive」リンクを追加（Blog の横）
- フッターの Site Contents セクションに「Blog Archive」リンクを追加

## Test plan
- [ ] ナビバーの Archive リンクが /blog/archive に遷移することを確認
- [ ] フッターの Blog Archive リンクが /blog/archive に遷移することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)