### PR TITLE
feat: フッターにSNSとブログリンクを追加

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -151,6 +151,18 @@ const config: Config = {
               label: 'Wantedly',
               href: 'https://www.wantedly.com/id/motoki_hirao',
             },
+            {
+              label: 'YOUTRUST',
+              href: 'https://youtrust.jp/users/motoki_hirao',
+            },
+            {
+              label: 'Bluesky',
+              href: 'https://bsky.app/profile/yumechi.bsky.social',
+            },
+            {
+              label: 'mixi2',
+              href: 'https://mixi.social/@yumechi',
+            },
           ],
         },
         {
@@ -167,6 +179,10 @@ const config: Config = {
             {
               label: 'Zenn',
               href: 'https://zenn.dev/yumechi',
+            },
+            {
+              label: 'note',
+              href: 'https://note.com/yumechi',
             },
           ],
         },


### PR DESCRIPTION
## Summary
- SNSセクションに YOUTRUST, Bluesky, mixi2 を追加
- Blog(Japanese)セクションに note を追加

## Test plan
- [ ] フッターの各リンクが正しいURLに遷移することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)