### PR TITLE
feat: GitHub issueからブログ記事を作成するワークフローを追加

### DIFF
--- a/.claude/skills/process-blog-issue/SKILL.md
+++ b/.claude/skills/process-blog-issue/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: process-blog-issue
+description: GitHub issueからブログ記事を作成しPRを作成します
+---
+
+# Process Blog Issue
+
+GitHub issueに記載されたブログ記事リクエストを処理し、記事を作成してPRを作成します。
+
+## 実行手順
+
+### 1. blog-request issueを取得
+
+以下のコマンドで `blog-request` ラベルが付いたオープンなissueを全て取得します：
+
+```bash
+gh issue list --label blog-request --state open --json number,title,body
+```
+
+取得したissueが0件の場合は「処理対象のissueがありません」と報告して終了します。
+
+**オプション**: ユーザーが特定のissue番号を指定した場合は、そのissueのみを処理します。
+
+### 2. 各issueを処理
+
+取得した各issueに対して、以下の処理を順番に実行します：
+
+#### 2.1 issueの内容をパース
+
+issueテンプレートから以下のフィールドを抽出します：
+
+- **ブログ記事のタイトル**: `### ブログ記事のタイトル` セクションの内容
+- **slug**: `### slug` セクションの内容
+- **タグ**: `### タグ` セクションの内容（カンマ区切り）
+- **資料のタイトル**: `### 資料のタイトル` セクションの内容
+- **資料のURL**: `### 資料のURL` セクションの内容
+- **感想・学び**: `### 感想・学び` セクションの内容
+
+#### 2.2 ブランチを作成
+
+mainブランチから、issue番号を含むブランチを作成します：
+
+```bash
+git checkout main
+git pull origin main
+git checkout -b blog/issue-<issue番号>
+```
+
+#### 2.3 ブログ記事を作成
+
+以下の形式でファイルを作成します：
+
+- **ファイルパス**: `blog/YYYY/MM-DD-<slug>/index.md`
+  - `YYYY` は現在の年
+  - `MM-DD` は現在の月日
+  - `slug` はissueから取得した値
+
+**ファイル内容**:
+
+```markdown
+---
+slug: /<slug>
+title: <ブログ記事のタイトル>
+authors: yumechi
+tags: [<タグをカンマ区切りで>]
+---
+
+<資料の簡単な紹介文を1-2文で生成>
+
+<!-- truncate -->
+
+## 資料リンク
+
+- [<資料のタイトル>](<資料のURL>)
+
+## 感想・学び
+
+<感想・学びの内容>
+```
+
+#### 2.4 コミット & プッシュ
+
+```bash
+git add blog/
+git commit -m "feat: <ブログ記事のタイトル>の記事を追加
+
+Closes #<issue番号>"
+git push -u origin blog/issue-<issue番号>
+```
+
+#### 2.5 PRを作成
+
+```bash
+gh pr create --title "feat: <ブログ記事のタイトル>" --body "## Summary
+
+- issueに基づいてブログ記事を作成しました
+
+## Related Issue
+
+Closes #<issue番号>
+
+---
+Generated with Claude Code"
+```
+
+### 3. 完了報告
+
+全てのissueの処理が完了したら、ユーザーに以下を報告します：
+
+- 処理したissueの数
+- 各issueに対して作成したPRのURL一覧
+- エラーがあった場合はその内容
+
+## 注意事項
+
+- slugは英数字とハイフンのみを使用（issueから取得した値をそのまま使用）
+- タグが空の場合は空配列 `[]` を設定
+- 感想が長い場合は適切に段落分けする
+- issueの内容が不足している場合はスキップしてユーザーに報告する
+- 複数のissueを処理する場合、各issueごとに別々のブランチとPRを作成する

--- a/.github/ISSUE_TEMPLATE/blog-request.yml
+++ b/.github/ISSUE_TEMPLATE/blog-request.yml
@@ -1,0 +1,59 @@
+name: ブログ記事リクエスト
+description: 読んだ記事やスライドの感想をブログ記事として作成するリクエスト
+title: "[Blog] "
+labels: ["blog-request"]
+body:
+  - type: input
+    id: blog-title
+    attributes:
+      label: ブログ記事のタイトル
+      description: ブログページに表示されるタイトル
+      placeholder: "例: React Hooksの基礎を学んだ"
+    validations:
+      required: true
+
+  - type: input
+    id: slug
+    attributes:
+      label: slug
+      description: URLに使用される識別子（英数字とハイフンのみ）
+      placeholder: "例: react-hooks-basics"
+    validations:
+      required: true
+
+  - type: input
+    id: tags
+    attributes:
+      label: タグ
+      description: 記事のタグ（カンマ区切り）
+      placeholder: "例: React, JavaScript, 学習"
+    validations:
+      required: false
+
+  - type: input
+    id: source-title
+    attributes:
+      label: 資料のタイトル
+      description: 読んだ記事/スライドのタイトル
+      placeholder: "例: React Hooks入門ガイド"
+    validations:
+      required: true
+
+  - type: input
+    id: source-url
+    attributes:
+      label: 資料のURL
+      description: 資料へのリンク
+      placeholder: "https://example.com/article"
+    validations:
+      required: true
+
+  - type: textarea
+    id: thoughts
+    attributes:
+      label: 感想・学び
+      description: 感想や学んだことを記載してください
+      placeholder: |
+        この記事を読んで学んだこと、感想、気づきなどを書いてください。
+    validations:
+      required: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,3 +57,12 @@ yumechi の個人ホームページです。プロフィールや読んだ記事
 プロジェクトをビルドしてローカルサーバーで確認する。
 
 **使い方**: `/build-test` を実行
+
+### process-blog-issue
+
+GitHub issueに記載されたブログ記事リクエストを処理し、記事を作成してPRを作成する。
+
+**使い方**: `/process-blog-issue` を実行
+- `blog-request` ラベルが付いた全てのオープンissueを自動的に処理
+- 各issueごとに別々のブランチとPRを作成
+- 特定のissue番号を指定した場合はそのissueのみ処理


### PR DESCRIPTION
## Summary

- GitHub issue テンプレート（`blog-request.yml`）を追加
- `process-blog-issue` skillを追加
- CLAUDE.mdに新しいskillの説明を追加

## 使い方

1. GitHubでissueを作成（テンプレート「ブログ記事リクエスト」を選択）
2. 必要な情報を入力
3. Claude Codeで `/process-blog-issue` を実行
4. 自動的にブログ記事が作成され、PRが作成される

## Test plan

- [ ] issueテンプレートが正しく表示されることを確認
- [ ] `/process-blog-issue` skillが正しく動作することを確認

---
Generated with Claude Code