### PR TITLE
fix: process-blog-issue skillの改善

### DIFF
--- a/.claude/skills/process-blog-issue/SKILL.md
+++ b/.claude/skills/process-blog-issue/SKILL.md
@@ -38,7 +38,7 @@ issueテンプレートから以下のフィールドを抽出します：
 
 #### 2.2 ブランチを作成
 
-mainブランチから、issue番号を含むブランチを作成します：
+**重要**: 各issueのブランチは必ずmainブランチから派生させます。複数のissueを処理する場合も、毎回mainブランチに戻ってから新しいブランチを作成してください。
 
 ```bash
 git checkout main
@@ -103,9 +103,17 @@ Closes #<issue番号>
 Generated with Claude Code"
 ```
 
-### 3. 完了報告
+### 3. mainブランチに戻る
 
-全てのissueの処理が完了したら、ユーザーに以下を報告します：
+全てのissueの処理が完了したら、必ずmainブランチに戻ります：
+
+```bash
+git checkout main
+```
+
+### 4. 完了報告
+
+ユーザーに以下を報告します：
 
 - 処理したissueの数
 - 各issueに対して作成したPRのURL一覧


### PR DESCRIPTION
## Summary

- 各issueのブランチは必ずmainから派生することを明記
- 全ての処理完了後にmainブランチに戻る手順を追加

## Test plan

- [ ] `/process-blog-issue` 実行時に各issueがmainから派生することを確認
- [ ] 処理完了後にmainブランチに戻ることを確認

---
Generated with Claude Code