### PR TITLE
feat: ブログ投稿統計グラフ生成ツールを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ yarn-error.log*
 /docusaurus.config.js
 /sidebars.js
 /src/**/*.js
+
+# Blog analytics tool outputs
+/output/
+/tools/blog-analytics/uv.lock

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,3 +66,9 @@ GitHub issueに記載されたブログ記事リクエストを処理し、記�
 - `blog-request` ラベルが付いた全てのオープンissueを自動的に処理
 - 各issueごとに別々のブランチとPRを作成
 - 特定のissue番号を指定した場合はそのissueのみ処理
+
+## ツール
+
+### ブログ投稿統計グラフ生成ツール
+
+ブログの投稿統計をグラフ化するツールです。詳細は [tools/blog-analytics/CLAUDE.md](./tools/blog-analytics/CLAUDE.md) を参照してください。

--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ mise run audit-fix
 - [Docusaurus](https://docusaurus.io/) - MIT License
 - [React](https://react.dev/) - MIT License
 
+## ツール
+
+- [ブログ投稿統計グラフ生成ツール](./tools/blog-analytics/README.md) - ブログの投稿統計を棒グラフで可視化するツール
+
 ## ライセンス
 
 このリポジトリのコンテンツは著作権で保護されています。コードは MIT License です。

--- a/tools/blog-analytics/CLAUDE.md
+++ b/tools/blog-analytics/CLAUDE.md
@@ -1,0 +1,68 @@
+# ブログ投稿統計グラフ生成ツール
+
+## 概要
+
+Docusaurusブログの投稿統計を棒グラフで可視化し、PNG出力するツールです。
+登壇資料などで活用するために作成されました。
+
+## 利用技術
+
+- Python 3.13
+- uv（パッケージマネージャー）
+- Altair / Vega-Lite（グラフ描画）
+- vl-convert-python（PNG出力）
+- Podman（コンテナ実行環境）
+
+## ディレクトリ構成
+
+```
+tools/blog-analytics/
+├── CLAUDE.md           # このファイル
+├── README.md           # 使用方法ドキュメント
+├── Containerfile       # Podmanコンテナビルド定義
+├── pyproject.toml      # Python依存関係定義
+├── uv.lock             # 依存関係ロックファイル（自動生成）
+└── blog_analytics.py   # メインスクリプト
+```
+
+## 機能
+
+1. **年間月別グラフ**: 指定した年の月ごと（1〜12月）の投稿数を棒グラフで表示
+2. **月間日別グラフ**: 指定した年月の日ごとの投稿数を棒グラフで表示
+
+## 基本的な使い方
+
+詳細は [README.md](./README.md) を参照してください。
+
+```bash
+# コンテナビルド（プロジェクトルートから実行）
+podman build -t blog-analytics tools/blog-analytics/
+
+# 年間月別グラフ生成
+mkdir -p output
+podman run --rm \
+  -v ./blog:/data/blog:ro \
+  -v ./output:/data/output \
+  blog-analytics --year 2023 --output /data/output/2023-monthly.png
+
+# 月間日別グラフ生成
+podman run --rm \
+  -v ./blog:/data/blog:ro \
+  -v ./output:/data/output \
+  blog-analytics --year 2023 --month 12 --output /data/output/2023-12-daily.png
+```
+
+## コマンドライン引数
+
+| 引数 | 説明 | 必須 |
+|------|------|------|
+| `--year YYYY` | 対象年 | ✅ |
+| `--month MM` | 対象月（指定すると日別グラフ） | - |
+| `--output PATH` | 出力ファイルパス | - |
+| `--blog-dir PATH` | ブログディレクトリ | - |
+
+## 注意事項
+
+- 出力ディレクトリ（`/output/`）はgitignore対象です
+- `uv.lock` は自動生成されるためgitignore対象です
+- ブログディレクトリは `blog/YYYY/MM-DD-slug/index.md` 形式を前提としています

--- a/tools/blog-analytics/Containerfile
+++ b/tools/blog-analytics/Containerfile
@@ -1,0 +1,22 @@
+# Python + uv環境でブログ投稿統計グラフを生成するコンテナ
+FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim
+
+# 日本語フォントをインストール（グラフラベル用）
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    fonts-noto-cjk \
+    && rm -rf /var/lib/apt/lists/*
+
+# 作業ディレクトリ設定
+WORKDIR /app
+
+# pyproject.tomlをコピー
+COPY pyproject.toml .
+
+# 依存関係をインストール
+RUN uv sync --no-dev
+
+# メインスクリプトをコピー
+COPY blog_analytics.py .
+
+# エントリポイント
+ENTRYPOINT ["uv", "run", "python", "/app/blog_analytics.py"]

--- a/tools/blog-analytics/README.md
+++ b/tools/blog-analytics/README.md
@@ -1,0 +1,85 @@
+# ブログ投稿統計グラフ生成ツール
+
+Docusaurusブログの投稿統計を棒グラフで可視化し、PNG出力するツールです。
+登壇資料などで活用するために作成されました。
+
+## 機能
+
+- **年間月別グラフ**: 指定した年の月ごと（1〜12月）のブログ投稿数を棒グラフで表示
+- **月間日別グラフ**: 指定した年月の日ごとの投稿数を棒グラフで表示
+
+## 前提条件
+
+- [Podman](https://podman.io/) がインストールされていること
+
+## 使用方法
+
+### コンテナのビルド
+
+プロジェクトルートで以下を実行：
+
+```bash
+podman build -t blog-analytics tools/blog-analytics/
+```
+
+### 年間月別グラフの生成
+
+```bash
+mkdir -p output
+podman run --rm \
+  -v ./blog:/data/blog:ro \
+  -v ./output:/data/output \
+  blog-analytics --year 2023 --output /data/output/2023-monthly.png
+```
+
+### 月間日別グラフの生成
+
+```bash
+podman run --rm \
+  -v ./blog:/data/blog:ro \
+  -v ./output:/data/output \
+  blog-analytics --year 2023 --month 12 --output /data/output/2023-12-daily.png
+```
+
+## コマンドライン引数
+
+| 引数 | 説明 | 必須 | デフォルト |
+|------|------|------|------------|
+| `--year YYYY` | 対象年 | ✅ | - |
+| `--month MM` | 対象月（1-12）。指定すると日別グラフを生成 | - | - |
+| `--output PATH` | 出力ファイルパス | - | `/data/output/stats.png` |
+| `--blog-dir PATH` | ブログディレクトリ | - | `/data/blog` |
+
+## ブログディレクトリ構造
+
+このツールは以下のディレクトリ構造を前提としています：
+
+```
+blog/
+├── YYYY/
+│   └── MM-DD-slug/
+│       └── index.md
+```
+
+例: `blog/2023/12-01-welcome/index.md` → 2023年12月1日の投稿
+
+## 技術スタック
+
+- Python 3.13
+- uv（パッケージマネージャー）
+- Altair / Vega-Lite（グラフ描画）
+- vl-convert-python（PNG出力）
+
+## 開発
+
+### ローカルでの実行（uv環境がある場合）
+
+```bash
+cd tools/blog-analytics
+uv sync
+uv run python blog_analytics.py --year 2023 --blog-dir ../../blog --output ./output.png
+```
+
+## ライセンス
+
+プロジェクトのライセンスに従います。

--- a/tools/blog-analytics/blog_analytics.py
+++ b/tools/blog-analytics/blog_analytics.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""
+ブログ投稿統計グラフ生成ツール
+
+Docusaurusブログの投稿統計を棒グラフで可視化し、PNG出力する。
+"""
+
+import argparse
+import re
+import sys
+from calendar import monthrange
+from collections import Counter
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+
+import altair as alt
+
+
+@dataclass
+class BlogPost:
+    """ブログ投稿を表すデータクラス"""
+    date: date
+    path: Path
+
+
+def parse_args() -> argparse.Namespace:
+    """コマンドライン引数を解析する"""
+    parser = argparse.ArgumentParser(
+        description="ブログ投稿統計グラフ生成ツール"
+    )
+    parser.add_argument(
+        "--year",
+        type=int,
+        required=True,
+        help="対象年（例: 2023）"
+    )
+    parser.add_argument(
+        "--month",
+        type=int,
+        choices=range(1, 13),
+        metavar="MM",
+        help="対象月（1-12）。指定すると日別グラフを生成"
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default="/data/output/stats.png",
+        help="出力ファイルパス（デフォルト: /data/output/stats.png）"
+    )
+    parser.add_argument(
+        "--blog-dir",
+        type=str,
+        default="/data/blog",
+        help="ブログディレクトリ（デフォルト: /data/blog）"
+    )
+    return parser.parse_args()
+
+
+def scan_blog_posts(blog_dir: Path) -> list[BlogPost]:
+    """
+    ブログディレクトリをスキャンして投稿リストを取得する
+
+    ディレクトリ構造: blog/YYYY/MM-DD-slug/index.md
+    """
+    posts: list[BlogPost] = []
+
+    if not blog_dir.is_dir():
+        print(f"警告: ブログディレクトリが見つかりません: {blog_dir}", file=sys.stderr)
+        return posts
+
+    # 年ディレクトリを探索
+    for year_dir in blog_dir.iterdir():
+        if not year_dir.is_dir():
+            continue
+
+        # 4桁の年かどうかを確認
+        if not re.match(r"^\d{4}$", year_dir.name):
+            continue
+
+        year = int(year_dir.name)
+
+        # 記事ディレクトリを探索
+        for post_dir in year_dir.iterdir():
+            if not post_dir.is_dir():
+                continue
+
+            # MM-DD-slug形式かどうかを確認
+            match = re.match(r"^(\d{2})-(\d{2})-", post_dir.name)
+            if not match:
+                continue
+
+            # index.mdが存在するか確認
+            index_file = post_dir / "index.md"
+            if not index_file.is_file():
+                continue
+
+            month = int(match.group(1))
+            day = int(match.group(2))
+
+            try:
+                post_date = date(year, month, day)
+                posts.append(BlogPost(date=post_date, path=post_dir))
+            except ValueError:
+                print(f"警告: 無効な日付: {year}-{month}-{day} ({post_dir.name})", file=sys.stderr)
+
+    return sorted(posts, key=lambda p: p.date)
+
+
+def generate_monthly_chart(posts: list[BlogPost], year: int, output_path: Path) -> None:
+    """年間月別投稿数の棒グラフを生成する"""
+    # 指定年の投稿をフィルタリング
+    year_posts = [p for p in posts if p.date.year == year]
+
+    # 月別にカウント
+    month_counts = Counter(p.date.month for p in year_posts)
+
+    # データを作成（1-12月すべて含める）
+    data = [
+        {"月": m, "投稿数": month_counts.get(m, 0)}
+        for m in range(1, 13)
+    ]
+
+    # グラフ作成
+    chart = alt.Chart(alt.Data(values=data)).mark_bar(
+        color="#4682B4"
+    ).encode(
+        x=alt.X("月:O", title="月", axis=alt.Axis(labelAngle=0)),
+        y=alt.Y("投稿数:Q", title="投稿数", axis=alt.Axis(tickMinStep=1)),
+        tooltip=["月:O", "投稿数:Q"]
+    ).properties(
+        title=f"{year}年 月別ブログ投稿数",
+        width=600,
+        height=400
+    ).configure_title(
+        fontSize=18,
+        anchor="middle"
+    ).configure_axis(
+        labelFontSize=12,
+        titleFontSize=14
+    )
+
+    # PNG保存
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    chart.save(str(output_path), ppi=150)
+
+    print(f"グラフを保存しました: {output_path}")
+    print(f"{year}年の総投稿数: {sum(month_counts.values())}件")
+
+
+def generate_daily_chart(posts: list[BlogPost], year: int, month: int, output_path: Path) -> None:
+    """月間日別投稿数の棒グラフを生成する"""
+    # 指定年月の投稿をフィルタリング
+    month_posts = [p for p in posts if p.date.year == year and p.date.month == month]
+
+    # 日別にカウント
+    day_counts = Counter(p.date.day for p in month_posts)
+
+    # その月の日数を取得
+    days_in_month = monthrange(year, month)[1]
+
+    # データを作成（1日から末日まですべて含める）
+    data = [
+        {"日": d, "投稿数": day_counts.get(d, 0)}
+        for d in range(1, days_in_month + 1)
+    ]
+
+    # グラフ作成
+    chart = alt.Chart(alt.Data(values=data)).mark_bar(
+        color="#4682B4"
+    ).encode(
+        x=alt.X("日:O", title="日", axis=alt.Axis(labelAngle=0)),
+        y=alt.Y("投稿数:Q", title="投稿数", axis=alt.Axis(tickMinStep=1)),
+        tooltip=["日:O", "投稿数:Q"]
+    ).properties(
+        title=f"{year}年{month}月 日別ブログ投稿数",
+        width=800,
+        height=400
+    ).configure_title(
+        fontSize=18,
+        anchor="middle"
+    ).configure_axis(
+        labelFontSize=12,
+        titleFontSize=14
+    )
+
+    # PNG保存
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    chart.save(str(output_path), ppi=150)
+
+    print(f"グラフを保存しました: {output_path}")
+    print(f"{year}年{month}月の総投稿数: {sum(day_counts.values())}件")
+
+
+def main() -> None:
+    """メイン処理"""
+    args = parse_args()
+
+    blog_dir = Path(args.blog_dir)
+    output_path = Path(args.output)
+
+    print(f"ブログディレクトリをスキャン中: {blog_dir}")
+    posts = scan_blog_posts(blog_dir)
+    print(f"検出した投稿数: {len(posts)}件")
+
+    if not posts:
+        print("警告: 投稿が見つかりませんでした", file=sys.stderr)
+
+    if args.month is None:
+        # 年間月別グラフ
+        generate_monthly_chart(posts, args.year, output_path)
+    else:
+        # 月間日別グラフ
+        generate_daily_chart(posts, args.year, args.month, output_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/blog-analytics/pyproject.toml
+++ b/tools/blog-analytics/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "blog-analytics"
+version = "0.1.0"
+description = "Docusaurusブログの投稿統計グラフ生成ツール"
+readme = "README.md"
+requires-python = ">=3.13"
+dependencies = [
+    "altair>=5.5",
+    "vl-convert-python>=1.9",
+]
+
+[dependency-groups]
+dev = [
+    "ruff>=0.11",
+    "ty>=0.0",
+]
+
+[tool.uv]
+package = false


### PR DESCRIPTION
## Summary
- Docusaurusブログの投稿統計を棒グラフで可視化し、PNG出力するツールを追加
- 年間月別グラフと月間日別グラフの2種類を生成可能
- Python 3.13 + uv + Altair/Vega-Lite で実装、Podmanコンテナで実行

## Test plan
- [ ] `podman build -t blog-analytics tools/blog-analytics/` でビルド確認
- [ ] `podman run --rm -v ./blog:/data/blog:ro -v ./output:/data/output blog-analytics --year 2023` で年間グラフ生成確認
- [ ] `podman run --rm -v ./blog:/data/blog:ro -v ./output:/data/output blog-analytics --year 2023 --month 12` で月間グラフ生成確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)