### PR TITLE
feat: GitHub Actions でブログ統計グラフを生成するワークフローを追加

### DIFF
--- a/.github/workflows/blog-analytics.yml
+++ b/.github/workflows/blog-analytics.yml
@@ -1,0 +1,87 @@
+name: Generate Blog Analytics
+
+on:
+  workflow_dispatch:
+    inputs:
+      years:
+        description: '対象年（カンマ区切り、空欄で全年）'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  generate:
+    name: Generate Blog Statistics
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        run: uv python install 3.13
+
+      - name: Install dependencies
+        working-directory: tools/blog-analytics
+        run: uv sync
+
+      - name: Create output directory
+        run: mkdir -p output
+
+      - name: Detect years with blog posts
+        id: detect-years
+        run: |
+          if [ -n "${{ inputs.years }}" ]; then
+            echo "years=${{ inputs.years }}" >> "$GITHUB_OUTPUT"
+          else
+            years=$(ls -d blog/[0-9][0-9][0-9][0-9] 2>/dev/null | xargs -n1 basename | tr '\n' ',' | sed 's/,$//')
+            echo "years=$years" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Generate monthly charts
+        working-directory: tools/blog-analytics
+        run: |
+          IFS=',' read -ra YEARS <<< "${{ steps.detect-years.outputs.years }}"
+          for year in "${YEARS[@]}"; do
+            year=$(echo "$year" | tr -d ' ')
+            echo "Generating monthly chart for $year..."
+            uv run python blog_analytics.py \
+              --year "$year" \
+              --blog-dir ../../blog \
+              --output "../../output/${year}-monthly.png"
+          done
+
+      - name: Generate daily charts
+        working-directory: tools/blog-analytics
+        run: |
+          IFS=',' read -ra YEARS <<< "${{ steps.detect-years.outputs.years }}"
+          for year in "${YEARS[@]}"; do
+            year=$(echo "$year" | tr -d ' ')
+            # Find months with posts for this year
+            if [ -d "../../blog/$year" ]; then
+              months=$(ls "../../blog/$year/" 2>/dev/null | grep -oE '^[0-9]{2}' | sort -u)
+              for month in $months; do
+                echo "Generating daily chart for $year-$month..."
+                uv run python blog_analytics.py \
+                  --year "$year" \
+                  --month "$((10#$month))" \
+                  --blog-dir ../../blog \
+                  --output "../../output/${year}-${month}-daily.png"
+              done
+            fi
+          done
+
+      - name: List generated files
+        run: ls -la output/
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: blog-analytics-charts
+          path: output/*.png
+          retention-days: 30


### PR DESCRIPTION
## Summary
- ローカル環境で Podman が使えない場合でも、GitHub Actions でブログ投稿統計グラフを生成できるようにした
- 手動実行（workflow_dispatch）でトリガー可能
- 生成されたグラフはアーティファクトとしてダウンロード可能

## 機能
- 対象年を指定可能（空欄で全年を自動検出）
- 年別月間グラフ（`YYYY-monthly.png`）を生成
- 投稿がある各月の日別グラフ（`YYYY-MM-daily.png`）を生成
- 30日間アーティファクトを保存

## Test plan
- [ ] Actions タブから「Generate Blog Analytics」を手動実行
- [ ] 実行完了後、アーティファクトからグラフをダウンロードして確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)