### PR TITLE
chore: blog-analytics ワークフローの Actions を最新化し保持日数を短縮

### DIFF
--- a/.github/workflows/blog-analytics.yml
+++ b/.github/workflows/blog-analytics.yml
@@ -16,10 +16,10 @@ jobs:
     name: Generate Blog Statistics
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
 
@@ -80,8 +80,8 @@ jobs:
         run: ls -la output/
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: blog-analytics-charts
           path: output/*.png
-          retention-days: 30
+          retention-days: 1


### PR DESCRIPTION
## Summary
- 使用している GitHub Actions を最新メジャーバージョンに更新
- アーティファクトの保持日数を30日から1日に短縮

## 変更内容
| Action | 変更前 | 変更後 |
|--------|--------|--------|
| actions/checkout | v4 | v6 |
| astral-sh/setup-uv | v5 | v7 |
| actions/upload-artifact | v4 | v6 |
| retention-days | 30 | 1 |

## Test plan
- [ ] Actions タブから「Generate Blog Analytics」を手動実行して動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)