### PR TITLE
fix: issue templateのtitleを空文字からプレースホルダーに変更

### DIFF
--- a/.github/ISSUE_TEMPLATE/blog-request.yml
+++ b/.github/ISSUE_TEMPLATE/blog-request.yml
@@ -1,6 +1,6 @@
 name: ブログ記事リクエスト
 description: 読んだ記事やスライドの感想をブログ記事として作成するリクエスト
-title: ""
+title: "タイトル"
 labels: ["blog-request"]
 body:
   - type: markdown


### PR DESCRIPTION
## Summary
- GitHub issue templateの`title`が空文字`""`だと「There is a problem with this template」エラーが発生するため、`"タイトル"`をプレースホルダーとして設定

## Test plan
- [ ] GitHub issueの新規作成画面でブログ記事リクエストテンプレートがエラーなく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)