### PR TITLE
chore: GitHub Actionsを最新メジャーバージョンに更新

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -12,11 +12,11 @@ jobs:
     name: Test deployment
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
         with:
           version: latest
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: 'pnpm'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,11 +15,11 @@ jobs:
     name: Deploy to GitHub Pages
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
         with:
           version: latest
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: 'pnpm'
@@ -29,7 +29,7 @@ jobs:
       - name: Build website
         run: pnpm build
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v4
         with:
           path: build
 


### PR DESCRIPTION
## Summary
- `actions/checkout` v4 → v6 (deploy-test.yml, deploy.yml)
- `actions/setup-node` v4 → v6 (deploy-test.yml, deploy.yml)
- `actions/upload-pages-artifact` v3 → v4 (deploy.yml)

## Test plan
- [ ] deploy-test.yml がPRのCIで正常に動作することを確認
- [ ] マージ後、deploy.yml のデプロイが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)