### PR TITLE
fix: qsパッケージの脆弱性を修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
   },
   "pnpm": {
     "overrides": {
-      "gray-matter>js-yaml": "3.14.2"
+      "gray-matter>js-yaml": "3.14.2",
+      "qs": ">=6.14.2"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   gray-matter>js-yaml: 3.14.2
+  qs: '>=6.14.2'
 
 importers:
 
@@ -4198,8 +4199,8 @@ packages:
     resolution: {integrity: sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==}
     engines: {node: '>=16.0.0'}
 
-  qs@6.14.1:
-    resolution: {integrity: sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==}
+  qs@6.15.0:
+    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
     engines: {node: '>=0.6'}
 
   queue-microtask@1.2.3:
@@ -7854,7 +7855,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.4.24
       on-finished: 2.4.1
-      qs: 6.14.1
+      qs: 6.15.0
       raw-body: 2.5.3
       type-is: 1.6.18
       unpipe: 1.0.0
@@ -8602,7 +8603,7 @@ snapshots:
       parseurl: 1.3.3
       path-to-regexp: 0.1.12
       proxy-addr: 2.0.7
-      qs: 6.14.1
+      qs: 6.15.0
       range-parser: 1.2.1
       safe-buffer: 5.2.1
       send: 0.19.2
@@ -10561,7 +10562,7 @@ snapshots:
 
   pvutils@1.1.5: {}
 
-  qs@6.14.1:
+  qs@6.15.0:
     dependencies:
       side-channel: 1.1.0
 


### PR DESCRIPTION
## Summary
- `qs` パッケージの脆弱性 (GHSA-w7fw-mjwx-w883, Low) を修正
- `pnpm.overrides` で `qs` を `>=6.14.2` に強制し、DoS脆弱性を解消
- 依存経路: `@docusaurus/core > webpack-dev-server > express > qs`

## Test plan
- [x] `pnpm audit` で脆弱性なしを確認
- [x] `pnpm build` でビルド成功を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)