### PR TITLE
CIでの日本語フォントレンダリングを修正

### DIFF
--- a/.github/workflows/blog-analytics.yml
+++ b/.github/workflows/blog-analytics.yml
@@ -26,6 +26,11 @@ jobs:
       - name: Set up Python
         run: uv python install 3.13
 
+      - name: Install Japanese fonts
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends fonts-noto-cjk
+
       - name: Install dependencies
         working-directory: tools/blog-analytics
         run: uv sync


### PR DESCRIPTION
ubuntu-latestランナーに日本語フォント（fonts-noto-cjk）がインストールされて
いないため、Altair/vl-convert-pythonで生成されるグラフの日本語テキストが
豆腐（□）になっていた。Containerfileにはフォントインストールが記述されて
いるが、CIワークフローはコンテナを使わず直接実行していたため反映されていなかった。

https://claude.ai/code/session_01MaV6MhpZ7AJfJGboavZ6ic