### PR TITLE
chore: GitHub Actions のバージョン更新と SHA 固定

### DIFF
--- a/.github/workflows/blog-analytics.yml
+++ b/.github/workflows/blog-analytics.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
         with:
           version: "latest"
 
@@ -85,7 +85,7 @@ jobs:
         run: ls -la output/
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: blog-analytics-charts
           path: output/*.png

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,4 +51,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0


### PR DESCRIPTION
## Summary
- サプライチェーン攻撃対策として GitHub Actions の参照を SHA に固定
- 同時に最新バージョン (リリースから 7 日以上経過したもの) に更新
- `pinact run --check` で pin 状態を検証済 (3 workflow すべて pinned)

## メジャー version 跨ぎ
- `astral-sh/setup-uv` v7 → v8
- `actions/upload-artifact` v6 → v7
- `actions/deploy-pages` v4 → v5

## Test plan
- [ ] workflow が文法的に valid であること
- [ ] Pages のビルド/デプロイが成功することを確認
- [ ] blog-analytics の手動実行が成功することを確認