### PR TITLE
chore: tools/blog-analytics の PNG を .gitignore に追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ yarn-error.log*
 
 # Blog analytics tool outputs
 /output/
+/tools/blog-analytics/*.png


### PR DESCRIPTION
## Summary

- `calc-blog-output` スキルが `tools/blog-analytics/` 配下に生成する PNG 画像が Git に追跡されないよう、`.gitignore` に `/tools/blog-analytics/*.png` を追加

## Test plan

- [x] `git status` で既存の `tools/blog-analytics/output.png` が untracked に表示されなくなること

🤖 Generated with [Claude Code](https://claude.com/claude-code)