### PR TITLE
chore: deploy-test ワークフローでMarkdownファイルの変更を除外

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
     # Review gh actions docs if you want to further define triggers, paths, etc
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
 


### PR DESCRIPTION
## Summary

- `.github/workflows/deploy-test.yml` に `paths-ignore` を追加
- Markdownファイル（`**/*.md`）のみの変更ではビルドテストが不要なため、ワークフローをスキップするよう設定