### PR TITLE
chore: RenovateからDependabotに切り替え

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "friday"
+      time: "21:00"
+      timezone: "Asia/Tokyo"
+    cooldown:
+      default-days: 7
+  - package-ecosystem: "uv"
+    directory: "/tools/blog-analytics"
+    schedule:
+      interval: "weekly"
+      day: "friday"
+      time: "21:00"
+      timezone: "Asia/Tokyo"
+    cooldown:
+      default-days: 7
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "friday"
+      time: "21:00"
+      timezone: "Asia/Tokyo"
+    cooldown:
+      default-days: 7

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
-  "minimumReleaseAge": "7 days"
-}


### PR DESCRIPTION
## Summary

- `renovate.json` を削除
- `.github/dependabot.yml` を追加
  - npm（ルート）
  - uv（`tools/blog-analytics`）
  - github-actions（ルート）
- スケジュール: 毎週金曜 21:00 JST
- `cooldown.default-days: 7` を設定し、リリース後7日間は更新PRを作成しない（Renovateの `minimumReleaseAge: 7 days` 相当）

## Background

RenovateをGitHub Actionsで動かすにはトークン設定が必要だが、DependabotはGitHubネイティブ機能で設定不要。他リポジトリもDependabotを利用しているため統一する。