### PR TITLE
chore(ci): pnpm/action-setup を廃止し corepack でセットアップ

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -15,7 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+      - name: Enable corepack
+        run: corepack enable
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 24

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+      - name: Enable corepack
+        run: corepack enable
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 24


### PR DESCRIPTION
## 背景

`pnpm/action-setup@v6` を Dependabot が提示した PR #206 が失敗しており、GitHub 上に既知の不具合が多数報告されている:

- `pnpm/action-setup#225` / `#227` / `#228`: v6 が bootstrap に pnpm v11 (RC) を使い、既存 pnpm v10 系の lockfile を壊すケースがある

また `pnpm/action-setup` 自体がサードパーティ Action のため、バージョン追従の負債になる。

## 変更内容

- `deploy-test.yml` / `deploy.yml` から `pnpm/action-setup` を削除
- 代わりに Node.js 標準の `corepack` で pnpm をセットアップ
- `corepack enable` を `actions/setup-node` より前に置くことで `pnpm` コマンドを PATH に用意し、`cache: 'pnpm'` をそのまま維持
- pnpm のバージョンは `package.json` の `packageManager` フィールド (`pnpm@10.32.1`) から corepack が自動解決する

## 追従

- PR #206 (Dependabot の v6 への bump) は本 PR マージ後に close する

## Test plan
- [ ] この PR の `Test deployment` CI が通ること
- [ ] マージ後、main への `Deploy to GitHub Pages` ワークフローが正常に完了すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)