### PR TITLE
ci: Python ツールの変更を Node ビルドから分離

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -6,6 +6,9 @@ on:
       - main
     paths-ignore:
       - '**/*.md'
+      - 'tools/**'
+      - '.github/workflows/blog-analytics.yml'
+      - '.github/workflows/tools-test.yml'
     # Review gh actions docs if you want to further define triggers, paths, etc
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'tools/**'
+      - '.github/workflows/blog-analytics.yml'
+      - '.github/workflows/tools-test.yml'
     # Review gh actions docs if you want to further define triggers, paths, etc
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
 

--- a/.github/workflows/tools-test.yml
+++ b/.github/workflows/tools-test.yml
@@ -1,0 +1,31 @@
+name: Test tools
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'tools/**'
+      - '.github/workflows/tools-test.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  test-install:
+    name: Test tools installation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        run: uv python install 3.13
+
+      - name: Install dependencies
+        working-directory: tools/blog-analytics
+        run: uv sync --frozen


### PR DESCRIPTION
## Summary

- `deploy-test.yml` / `deploy.yml` の `paths-ignore` に `tools/**`、`blog-analytics.yml`、`tools-test.yml` を追加し、Python ツールのみの変更では Docusaurus ビルドが走らないようにする
- 新規 `tools-test.yml` を追加し、`tools/**` 変更時に `uv sync --frozen` でインストール可能性を確認する

## Motivation

dependabot の ruff/ty bump（例: #209）のように `tools/blog-analytics` のみを変更する PR では、Node のビルドテストやデプロイは不要。一方で Python スクリプト側のテストが無いのも不安なので、最低限「インストールできること」を新規ワークフローで確認する。

## Notes

- `deploy.yml` には `**/*.md` は含めていない（blog 記事 md 追加のみの PR がマージされた際に本番デプロイが走らなくなるのを避けるため）。
- `tools-test.yml` は現状 `tools/blog-analytics` 決め打ちだが、将来別ツールが増えたら matrix 化などを検討する。

## Test plan

- [ ] Python 系のみ変更した PR で `Test tools` のみが走り、`Test deployment` が skip されること
- [ ] blog 記事や src 変更の PR で従来通り `Test deployment` が走ること
- [ ] main への Python 系のみの push で `Deploy to GitHub Pages` が skip されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)