### PR TITLE
chore: bump pnpm from 10.32.1 to 11.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,14 +55,8 @@
       "last 5 safari version"
     ]
   },
-  "packageManager": "pnpm@10.32.1",
+  "packageManager": "pnpm@11.6.0",
   "engines": {
     "node": ">=22.0"
-  },
-  "pnpm": {
-    "overrides": {
-      "serialize-javascript@<=7.0.2": "7.0.3",
-      "webpackbar": "^7.0.0"
-    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,14 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  js-yaml@<3.14.2: '>=3.14.2'
+  js-yaml@>=4.0.0 <4.1.1: '>=4.1.1'
+  lodash@>=4.0.0 <=4.17.22: '>=4.17.23'
+  mdast-util-to-hast@>=13.0.0 <13.2.1: '>=13.2.1'
+  node-forge@<1.3.2: '>=1.3.2'
+  on-headers@<1.1.0: '>=1.1.0'
+  qs@<6.14.1: '>=6.14.1'
+  webpack-dev-server@<=5.2.0: '>=5.2.1'
   serialize-javascript@<=7.0.2: 7.0.3
   webpackbar: ^7.0.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+allowBuilds:
+  core-js: false
+
 minimumReleaseAge: 10080 # 7 days
 
 overrides:
@@ -9,3 +12,5 @@ overrides:
   on-headers@<1.1.0: '>=1.1.0'
   qs@<6.14.1: '>=6.14.1'
   webpack-dev-server@<=5.2.0: '>=5.2.1'
+  serialize-javascript@<=7.0.2: '7.0.3'
+  webpackbar: '^7.0.0'


### PR DESCRIPTION
## Summary

- `packageManager` を `pnpm@10.32.1` → `pnpm@11.6.0` に更新
- pnpm 11 で廃止された `package.json` の `pnpm.overrides` を `pnpm-workspace.yaml` の `overrides` セクションに移動
- `core-js` のビルドスクリプトを `allowBuilds: false` で明示的に無効化（既存の `ignore-scripts=true` に合わせる）

## Test plan

- [ ] CI の Test deployment が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)