### PR TITLE
fix: js-yaml override の上限を設定しビルドエラーを解消

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  js-yaml@<3.14.2: '>=3.14.2'
+  js-yaml@<3.14.2: '>=3.14.2 <4'
   js-yaml@>=4.0.0 <4.1.1: '>=4.1.1'
   lodash@>=4.0.0 <=4.17.22: '>=4.17.23'
   mdast-util-to-hast@>=13.0.0 <13.2.1: '>=13.2.1'
@@ -734,10 +734,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-
-  '@babel/runtime@7.29.2':
-    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
-    engines: {node: '>=6.9.0'}
 
   '@babel/runtime@7.29.7':
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
@@ -7219,8 +7215,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/runtime@7.29.2': {}
-
   '@babel/runtime@7.29.7': {}
 
   '@babel/template@7.28.6':
@@ -7604,7 +7598,7 @@ snapshots:
       '@babel/preset-env': 7.29.2(@babel/core@7.29.0)
       '@babel/preset-react': 7.28.5(@babel/core@7.29.0)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       '@babel/traverse': 7.29.0
       '@docusaurus/logger': 3.10.1
       '@docusaurus/utils': 3.10.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -10810,7 +10804,7 @@ snapshots:
 
   gray-matter@4.0.3:
     dependencies:
-      js-yaml: 4.2.0
+      js-yaml: 3.14.2
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
@@ -13114,19 +13108,19 @@ snapshots:
 
   react-loadable-ssr-addon-v5-slorber@1.0.3(@docusaurus/react-loadable@6.0.0(react@19.2.5))(webpack@5.106.2):
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@19.2.5)'
       webpack: 5.106.2
 
   react-router-config@5.1.1(react-router@5.3.4(react@19.2.5))(react@19.2.5):
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       react: 19.2.5
       react-router: 5.3.4(react@19.2.5)
 
   react-router-dom@5.3.4(react@19.2.5):
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       history: 4.10.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
@@ -13137,7 +13131,7 @@ snapshots:
 
   react-router@5.3.4(react@19.2.5):
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       history: 4.10.1
       hoist-non-react-statics: 3.3.2
       loose-envify: 1.4.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,7 +4,7 @@ allowBuilds:
 minimumReleaseAge: 10080 # 7 days
 
 overrides:
-  js-yaml@<3.14.2: '>=3.14.2'
+  js-yaml@<3.14.2: '>=3.14.2 <4'
   js-yaml@>=4.0.0 <4.1.1: '>=4.1.1'
   lodash@>=4.0.0 <=4.17.22: '>=4.17.23'
   mdast-util-to-hast@>=13.0.0 <13.2.1: '>=13.2.1'


### PR DESCRIPTION
## 概要

`docusaurus build` が front matter のパースで失敗し、CI（Test deployment）が落ちていた問題を修正します。

## 原因

`pnpm-workspace.yaml` のセキュリティ override に上限が無く、意図しないメジャーバージョンを引いていました。

```yaml
js-yaml@<3.14.2: '>=3.14.2'   # ← 上限なし
```

脆弱な js-yaml 3.x 系（3.14.2 未満）を引き上げる意図でしたが、置換先 `'>=3.14.2'` が上限なしの範囲のため、pnpm が条件に合う最新版＝ **js-yaml 4.2.0** を解決していました。

`gray-matter@4.0.3`（Docusaurus が front matter 解析に使用）は js-yaml 3.x の `yaml.safeLoad` を呼びますが、これは js-yaml 4.x で削除済みです。結果として以下のエラーでビルドが失敗していました。

```
Error: Function yaml.safeLoad is removed in js-yaml 4. Use yaml.load instead, which is now safe by default.
```

オープン中の react / react-dom の Dependabot PR（#256, #259）はこれと無関係で、main 自体のビルドが壊れていたため巻き込まれて失敗していました。

## 修正内容

override の置換先に上限を追加し、gray-matter を js-yaml 3.14.2 に固定します。

```yaml
js-yaml@<3.14.2: '>=3.14.2 <4'
```

- 脆弱性対応（3.14.2 への引き上げ）は維持
- js-yaml 4.x を正規に利用するパッケージには別 override（`js-yaml@>=4.0.0 <4.1.1`）が効くため影響なし
- lockfile を再生成

## 検証

- lockfile 再生成後、`gray-matter@4.0.3 → js-yaml: 3.14.2` を確認
- `pnpm build` がローカルで成功（front matter エラー解消）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W7wyQzUrSLmTU1naV8EW9w

---
_Generated by [Claude Code](https://claude.ai/code/session_01W7wyQzUrSLmTU1naV8EW9w)_